### PR TITLE
fixed calculation of rake id (verison); fixed extraction of rake task…

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,10 @@ namespace :users do
     User.update_all({role_id: 1}, {role_id: 2})
 
     # DO NOT REMOVE THIS PART
-    RakeMigration.find_or_create_by_version(__FILE__[/\d+/])
+    RakeMigration.mark_complete(__FILE__)
   end
 end
 ```
-
-Update: If you are using Rails 4 or greater, the find_or_create_by_version has been changed to find_or_create_by(version: __FILE__[/\d+/]).
 
 Simply insert your code above the "DO NOT REMOVE THIS PART" line. The checklist is there to help you and the person who is code-reviewing your code to think of problems that might occur from your rake task. Afterwards you can run the rake task normally:
 

--- a/lib/rails/generators/rake_migrations/templates/rake_migrations_check.rb
+++ b/lib/rails/generators/rake_migrations/templates/rake_migrations_check.rb
@@ -6,12 +6,13 @@ module RakeMigrationsCheck
     results = client.query("select * from rake_migrations").map {|res| res["version"] }
     rake_migrations_lib = "#{`pwd`.strip}/lib/tasks/rake_migrations/*"
 
-    rake_files = Dir[rake_migrations_lib].map do |file|
-      if !results.include?(file[/\d+/])
+    rake_files = Dir[rake_migrations_lib].sort.map do |file|
+      rake_id = RakeMigration.version_from_path(file)
+      if !results.include?(rake_id)
         file = File.read(file)
-        namespace = file[/namespace :(.*?)do/m, 1].strip
-        task = file[/task (.*?):/m, 1]
-        "rake #{namespace}:#{task}"
+        namespace = file[/namespace :?([^: ,]*)/m, 1].strip
+        task = file[/task :?([^ :,]*)/m, 1]
+        "rake #{namespace}:#{task} # #{rake_id}"
       end
     end.compact
 

--- a/lib/rails/generators/task/templates/task.rb
+++ b/lib/rails/generators/task/templates/task.rb
@@ -14,11 +14,7 @@ namespace :<%= file_name %> do
 
 
     # DO NOT REMOVE THIS PART
-<% if Rails.version.to_i < 4 -%>
-    RakeMigration.find_or_create_by_version(__FILE__[/\d+/])
-<% else -%>
-    RakeMigration.find_or_create_by(version: __FILE__[/\d+/])
-<% end -%>
+    RakeMigration.mark_complete(__FILE__)
   end
 <% end -%>
 end

--- a/lib/rake_migration.rb
+++ b/lib/rake_migration.rb
@@ -1,2 +1,18 @@
 class RakeMigration < ::ActiveRecord::Base
+  def self.version_from_path(path)
+    path.split('/').last[/\d+/]
+  end
+
+  def self.findcreate_by_version(rake_id)
+    find_or_create_by_version(rake_id)
+  end
+
+  def self.mark_complete(file)
+    rake_id = version_from_path(file)
+    if methods.include?(:find_or_create_by)
+      find_or_create_by(version: rake_id)
+    else
+      findcreate_by_version(rake_id)
+    end
+  end
 end

--- a/spec/lib/generators/task_generator_spec.rb
+++ b/spec/lib/generators/task_generator_spec.rb
@@ -33,7 +33,7 @@ describe TaskGenerator do
     end
 
     it "should have the RakeMigration update" do
-      assert_file "lib/tasks/rake_migrations/#{@timestamp}_users.rake", /RakeMigration.find_or_create_by\(version\:/
+      assert_file "lib/tasks/rake_migrations/#{@timestamp}_users.rake", /RakeMigration.mark_complete/
     end
   end
 
@@ -53,7 +53,7 @@ describe TaskGenerator do
     end
 
     it "should have the RakeMigration update" do
-      assert_file "lib/tasks/rake_migrations/#{@timestamp}_users.rake", /RakeMigration.find_or_create_by_version/
+      assert_file "lib/tasks/rake_migrations/#{@timestamp}_users.rake", /RakeMigration.mark_complete/
     end
   end
 end

--- a/spec/lib/rake_migration_spec.rb
+++ b/spec/lib/rake_migration_spec.rb
@@ -1,0 +1,25 @@
+require 'active_record'
+require 'rake_migration'
+
+describe RakeMigration do
+  context "version_from_path" do
+    it "should extract rake id from file name" do
+      expect(RakeMigration.version_from_path('a/2/201810162054_xyz.rake3')).to eq('201810162054')
+      expect(RakeMigration.version_from_path('2/201810162054_xyz.rake3')).to eq('201810162054')
+    end
+  end
+
+  context "mark_complete" do
+    it "should use find_or_create_by for rails 4" do
+      allow(RakeMigration).to receive_message_chain(:methods,:include?).and_return(true)
+      expect(RakeMigration).to receive(:find_or_create_by).with(hash_including(:version)).and_return(true)
+      RakeMigration.mark_complete('a/2/201810162054_xyz.rake3')
+    end
+
+    it "should use find_or_create_by_version for rails 3" do
+      allow(RakeMigration).to receive_message_chain(:methods,:include?).and_return(false)
+      allow(RakeMigration).to receive(:findcreate_by_version).and_return('something')
+      expect(RakeMigration.mark_complete('a/2/201810162054_xyz.rake3')).to eq('something')
+    end
+  end
+end


### PR DESCRIPTION
Fixed: 
1. cases where ```__FILE__``` contained numeric element other than the rake's name, the rake-id was not detected correctly
2. rakes were not listed sorted by date, so you might run your rakes in wrong order
3. some rakes were listed incorrectly because their namespace and/or task name was detected wrong
4. template for rake generator fixed so rake_id is detected correctly when marking "completed" in database

TODO: handle rakes with more than 1 task